### PR TITLE
Fix for missing plasmoid git link in debian installer

### DIFF
--- a/kde_plasmoid_debian/Readme.md
+++ b/kde_plasmoid_debian/Readme.md
@@ -1,6 +1,14 @@
 # Mycroft Plasmoid // Release 2.0
 #### Mycroft Ai Plasmoid and Skills for KDE Plasma 5 Desktop
 
+Auto Install Instructions:
+
+1. git clone https://github.com/MycroftAI/installers/kde_plasmoid_debian
+2. chmod +x install.sh
+3. ./install.sh
+
+Manual Install Instructions: 
+
 1. Installation Requirements
 
   + This plasmoid requires Mycroft Core Installed from http://github.com/MycroftAi/ using the GIT Method:

--- a/kde_plasmoid_debian/Readme.md
+++ b/kde_plasmoid_debian/Readme.md
@@ -1,9 +1,9 @@
 # Mycroft Plasmoid // Release 2.0
-#### Mycroft Ai Plasmoid and Skills for KDE Plasma 5 Desktop
+#### Mycroft AI Plasmoid and Skills for KDE Plasma 5 Desktop
 
 Auto Install Instructions:
 
-1. git clone https://github.com/MycroftAI/installers/kde_plasmoid_debian
+1. wget https://raw.githubusercontent.com/MycroftAI/installers/master/kde_plasmoid_debian/install.sh
 2. chmod +x install.sh
 3. ./install.sh
 
@@ -11,7 +11,7 @@ Manual Install Instructions:
 
 1. Installation Requirements
 
-  + This plasmoid requires Mycroft Core Installed from http://github.com/MycroftAi/ using the GIT Method:
+  + This plasmoid requires Mycroft Core Installed from http://github.com/MycroftAI/ using the GIT Method:
     + cd /home/$USER/
     + git clone https://github.com/MycroftAI/mycroft-core
     + For Debian Run: ./build_host_setup_debian.sh

--- a/kde_plasmoid_debian/Readme.md
+++ b/kde_plasmoid_debian/Readme.md
@@ -1,0 +1,58 @@
+# Mycroft Plasmoid // Release 2.0
+#### Mycroft Ai Plasmoid and Skills for KDE Plasma 5 Desktop
+
+1. Installation Requirements
+
+  + This plasmoid requires Mycroft Core Installed from http://github.com/MycroftAi/ using the GIT Method:
+    + cd /home/$USER/
+    + git clone https://github.com/MycroftAI/mycroft-core
+    + For Debian Run: ./build_host_setup_debian.sh
+    + Run: ./dev_setup.sh
+
+2. Installation Instructions
+  + Konsole: sudo apt-get install libkf5notifications-data libkf5notifications-dev qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-controls qml-module-qtwebsockets qml-module-qt-websockets qtdeclarative5-qtquick2-plugin qtdeclarative5-models-plugin cmake cmake-extras cmake-data qml-module-qtquick-layouts libkf5plasma-dev extra-cmake-modules qtdeclarative5-dev build-essential g++ gettext libqt5webkit5 libqt5webkit5-dev libkf5i18n-data libkf5i18n-dev libkf5i18n5 -y
+  + git clone https://anongit.kde.org/plasma-mycroft.git/
+  + mkdir build
+  + cd build
+  + cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release   -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
+  + make
+  + sudo make install
+  + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/startservice.sh
+  + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/stopservice.sh
+  + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstartservice.sh
+  + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
+  + Logout / Login or Restart Plasma Shell
+
+3. Skills Installation
+
+ + skill-weather: Replace /opt/mycroft/skills/skill-weather with https://github.com/AIIX/skill-weather
+    + git clone https://github.com/AIIX/skill-weather
+    + cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
+ 
+ + skill-stocks: Replace /opt/mycroft/skills/skill-stock with https://github.com/AIIX/skill-stock
+    + git clone https://github.com/AIIX/skill-stock
+    + cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
+    
+ + skill-wiki: Replace /opt/mycroft/skills/skill-wiki with https://github.com/AIIX/skill-wiki
+    + git clone https://github.com/AIIX/skill-wiki
+    + cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
+
+Plasma Desktop Skills(Manually) (Step 5. Dependency Install is Very Important):
+    + git clone https://github.com/AIIX/krunner-search-skill  
+    + cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
+    + git clone https://github.com/AIIX/plasma-activities-skill  
+    + cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
+    + git clone https://github.com/AIIX/plasma-user-control-skill
+    + cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
+    + git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
+    + cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
+    + git clone https://github.com/AIIX/clarifai-image-recognition-skill  
+    + cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
+    
+5. Skills Dependency Requirements
+
+ + For Skills (KDE Neon): sudo apt install python-dbus, python-pyqt5 pyqt5-dev, python-sip, python-sip-dev
+ + From Konsole: cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+ + From Konsole: cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+ + From Konsole: cp -R /usr/lib/python2.7/dist-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+ + From Konsole: cp /usr/lib/python2.7/dist-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/

--- a/kde_plasmoid_debian/core_build.sh
+++ b/kde_plasmoid_debian/core_build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Make sure we are in user's home directory
+cd ~
+
+echo "*****************************************************"
+echo "Installing git for pulling down source code"
+echo "*****************************************************"
+sudo apt-get install git -y
+
+############################################################################
+# Retrieve and build Mycroft
+############################################################################
+
+# Pull down mycroft-core
+git clone https://github.com/MycroftAI/mycroft-core.git
+
+# Build and install Mycroft:
+cd mycroft-core
+
+echo "*****************************************************"
+echo "Getting Requirements."
+echo "*****************************************************"
+./build_host_setup_debian.sh
+echo "-----------------------------------------------------"
+echo "-----------------------------------------------------"

--- a/kde_plasmoid_debian/core_build.sh
+++ b/kde_plasmoid_debian/core_build.sh
@@ -12,7 +12,7 @@ sudo apt-get install git -y
 ############################################################################
 
 # Pull down mycroft-core
-git clone https://github.com/MycroftAI/mycroft-core.git
+#git clone https://github.com/MycroftAI/mycroft-core.git
 
 # Build and install Mycroft:
 cd mycroft-core

--- a/kde_plasmoid_debian/core_dev.sh
+++ b/kde_plasmoid_debian/core_dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Make sure we are in user's home directory
+cd ~
+cd mycroft-core
+
+echo "*****************************************************"
+echo "The compiling can take a long time, up to 2 hours."
+echo "Go enjoy a movie, we'll finish the install.       "
+echo "*****************************************************"
+./dev_setup.sh
+echo "-----------------------------------------------------"
+echo "Whew, finally finished that!"
+echo "-----------------------------------------------------"

--- a/kde_plasmoid_debian/install.sh
+++ b/kde_plasmoid_debian/install.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+echo "**********************************************************************"
+echo "                 Mycroft Plasmoid installation script                 "
+echo "                                                                      "
+echo "This script will download, build and install the Mycroft core and the "
+echo "Mycroft KDE Plasmoid.  Special thanks to AIX for making all of this   "
+echo "possible!                                                             "
+echo "**********************************************************************"
+echo ""
+echo ""
+
+# Make sure we are in user's home directory
+cd ~
+
+echo "*****************************************************"
+echo "Installing git for pulling down source code"
+echo "*****************************************************"
+sudo apt-get install git -y
+
+############################################################################
+# Retrieve and build Mycroft
+############################################################################
+
+# Pull down mycroft-core
+git clone https://github.com/MycroftAI/mycroft-core.git
+
+# Build and install Mycroft:
+cd mycroft-core
+
+echo "*****************************************************"
+echo "The compiling can take a long time, up to 2 hours."
+echo "Go enjoy a movie, we'll finish the install.       "
+echo "*****************************************************"
+./build_host_setup_debian.sh
+./dev_setup.sh
+echo "-----------------------------------------------------"
+echo "Whew, finally finished that!  Now on to the Plasmoid "
+echo "-----------------------------------------------------"
+
+
+############################################################################
+# Retrieve and build the Plasmoid
+############################################################################
+
+
+# Install all necessary supporting libraries and tools
+sudo apt-get install libkf5notifications-data libkf5notifications-dev qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-controls qml-module-qtwebsockets qml-module-qt-websockets qtdeclarative5-qtquick2-plugin qtdeclarative5-models-plugin cmake cmake-extras cmake-data qml-module-qtquick-layouts libkf5plasma-dev extra-cmake-modules qtdeclarative5-dev build-essential g++ gettext libqt5webkit5 libqt5webkit5-dev libkf5i18n-data libkf5i18n-dev libkf5i18n5 -y
+
+# Build the Plasmoid
+cd plasma-mycroft
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
+make
+
+# Install the Plasmoid
+sudo make install
+
+# Set permissions on new files to allow execution
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/startservice.sh
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/stopservice.sh
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstartservice.sh
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
+
+############################################################################
+# Installing Skills Dependencies
+############################################################################
+
+# Install all necessary supporting libraries
+sudo apt-get install python-dbus python-pyqt5 pyqt5-dev python-sip python-sip-dev
+cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp -R /usr/lib/python2.7/dist-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+cp /usr/lib/python2.7/dist-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+
+# Get those awesome plasma skills
+git clone https://github.com/AIIX/krunner-search-skill  
+cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
+git clone https://github.com/AIIX/plasma-activities-skill  
+cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
+git clone https://github.com/AIIX/plasma-user-control-skill  
+cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
+git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
+cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
+git clone https://github.com/AIIX/clarifai-image-recognition-skill  
+cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
+
+#Get those display skills for the desktop
+git clone https://github.com/AIIX/skill-weather
+cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
+git clone https://github.com/AIIX/skill-stock
+cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
+git clone https://github.com/AIIX/skill-wiki
+cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
+
+# Restart the machine!
+echo "Everything is built and ready to go!"
+echo "After the machine reboots, you will need to activate it by:"
+echo "1) Right-clicking on the desktop and picking 'Add Widget...'"
+echo "2) Locating 'Mycroft' and dragging that to the desktop"
+echo "3) Click on the Plasmoid and press the 'Play' button"
+echo "4) Register your devices at https://home.mycroft.ai with the pairing code"
+echo "5) Say 'Hey Mycroft, what time is it?'"
+
+read -p "Press the [Enter] key to reboot..."
+sudo reboot now

--- a/kde_plasmoid_debian/install.sh
+++ b/kde_plasmoid_debian/install.sh
@@ -42,7 +42,7 @@ echo "-----------------------------------------------------"
 ############################################################################
 # Retrieve and build the Plasmoid
 ############################################################################
-
+cd ..
 # Pull down the Plasmoid code from KDE repos
 git clone https://anongit.kde.org/plasma-mycroft.git
 

--- a/kde_plasmoid_debian/install.sh
+++ b/kde_plasmoid_debian/install.sh
@@ -43,6 +43,8 @@ echo "-----------------------------------------------------"
 # Retrieve and build the Plasmoid
 ############################################################################
 
+# Pull down the Plasmoid code from KDE repos
+git clone https://anongit.kde.org/plasma-mycroft.git
 
 # Install all necessary supporting libraries and tools
 sudo apt-get install libkf5notifications-data libkf5notifications-dev qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-controls qml-module-qtwebsockets qml-module-qt-websockets qtdeclarative5-qtquick2-plugin qtdeclarative5-models-plugin cmake cmake-extras cmake-data qml-module-qtquick-layouts libkf5plasma-dev extra-cmake-modules qtdeclarative5-dev build-essential g++ gettext libqt5webkit5 libqt5webkit5-dev libkf5i18n-data libkf5i18n-dev libkf5i18n5 -y

--- a/kde_plasmoid_debian/plasmaskills.sh
+++ b/kde_plasmoid_debian/plasmaskills.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Make sure we are in user's home directory
+cd ~
+
+cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp -R /usr/lib/python2.7/dist-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+cp /usr/lib/python2.7/dist-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+
+# Get those awesome plasma skills
+git clone https://github.com/AIIX/krunner-search-skill  
+cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
+git clone https://github.com/AIIX/plasma-activities-skill  
+cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
+git clone https://github.com/AIIX/plasma-user-control-skill  
+cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
+git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
+cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
+git clone https://github.com/AIIX/clarifai-image-recognition-skill  
+cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
+
+# Get those display skills for the desktop
+git clone https://github.com/AIIX/skill-weather
+cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
+git clone https://github.com/AIIX/skill-stock
+cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
+git clone https://github.com/AIIX/skill-wiki
+cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/

--- a/kde_plasmoid_debian/plasmoid.sh
+++ b/kde_plasmoid_debian/plasmoid.sh
@@ -34,30 +34,6 @@ sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/content
 
 # Install all necessary supporting libraries
 sudo apt-get install python-dbus python-pyqt5 pyqt5-dev python-sip python-sip-dev
-cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp -R /usr/lib/python2.7/dist-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
-cp /usr/lib/python2.7/dist-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-
-# Get those awesome plasma skills
-git clone https://github.com/AIIX/krunner-search-skill  
-cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
-git clone https://github.com/AIIX/plasma-activities-skill  
-cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
-git clone https://github.com/AIIX/plasma-user-control-skill  
-cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
-git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
-cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
-git clone https://github.com/AIIX/clarifai-image-recognition-skill  
-cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
-
-#Get those display skills for the desktop
-git clone https://github.com/AIIX/skill-weather
-cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
-git clone https://github.com/AIIX/skill-stock
-cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
-git clone https://github.com/AIIX/skill-wiki
-cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
 
 # Restart the machine!
 echo "Everything is built and ready to go!"s

--- a/kde_plasmoid_debian/plasmoid.sh
+++ b/kde_plasmoid_debian/plasmoid.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Make sure we are in user's home directory
+cd ~
+
+############################################################################
+# Retrieve and build the Plasmoid
+############################################################################
+
+# Pull down the Plasmoid code from KDE repos
+git clone https://anongit.kde.org/plasma-mycroft.git
+
+# Install all necessary supporting libraries and tools
+sudo apt-get install libkf5notifications-data libkf5notifications-dev qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-controls qml-module-qtwebsockets qml-module-qt-websockets qtdeclarative5-qtquick2-plugin qtdeclarative5-models-plugin cmake cmake-extras cmake-data qml-module-qtquick-layouts libkf5plasma-dev extra-cmake-modules qtdeclarative5-dev build-essential g++ gettext libqt5webkit5 libqt5webkit5-dev libkf5i18n-data libkf5i18n-dev libkf5i18n5 -y
+
+# Build the Plasmoid
+cd plasma-mycroft
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
+make
+
+# Install the Plasmoid
+sudo make install
+
+# Set permissions on new files to allow execution
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/startservice.sh
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/stopservice.sh
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstartservice.sh
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
+
+############################################################################
+# Installing Skills Dependencies
+############################################################################
+
+# Install all necessary supporting libraries
+sudo apt-get install python-dbus python-pyqt5 pyqt5-dev python-sip python-sip-dev
+cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp -R /usr/lib/python2.7/dist-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+cp /usr/lib/python2.7/dist-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+
+# Get those awesome plasma skills
+git clone https://github.com/AIIX/krunner-search-skill  
+cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
+git clone https://github.com/AIIX/plasma-activities-skill  
+cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
+git clone https://github.com/AIIX/plasma-user-control-skill  
+cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
+git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
+cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
+git clone https://github.com/AIIX/clarifai-image-recognition-skill  
+cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
+
+#Get those display skills for the desktop
+git clone https://github.com/AIIX/skill-weather
+cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
+git clone https://github.com/AIIX/skill-stock
+cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
+git clone https://github.com/AIIX/skill-wiki
+cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
+
+# Restart the machine!
+echo "Everything is built and ready to go!"s

--- a/kde_plasmoid_fedora/Readme.md
+++ b/kde_plasmoid_fedora/Readme.md
@@ -1,0 +1,70 @@
+# Mycroft Plasmoid // Release 2.0
+#### Mycroft Ai Plasmoid and Skills for KDE Plasma 5 Desktop
+
+1. Installation Requirements
+
+This plasmoid requires Mycroft Core Installed from http://github.com/MycroftAi/ using the GIT Method:
+    + cd /home/$USER/
+    + git clone https://github.com/MycroftAI/mycroft-core
+    + For Fedora Run: ./build_host_setup_fedora.sh
+    + Run: ./dev_setup.sh
+
+2. Installation Instructions
+  + Open Konsole: sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquick1-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets cmake extra-cmake-modules kf5-plasma-devel kf5-i18n-devel qt5-qtwebkit qt5-qtwebkit-devel
+  + git clone https://anongit.kde.org/plasma-mycroft.git/
+  + mkdir build
+  + cd build
+  + cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release   -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
+  + make
+  + sudo make install
+  + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/startservice.sh
+  + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/stopservice.sh
+  + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstartservice.sh
+  + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
+  + Logout / Login or Restart Plasma Shell
+
+3. Skills Installation
+
+ Install Skills from Plasmoid:
+ + For Krunner Skill: Install from Plasmoid (Follow Dependency Installation Below). Skill Name: Krunner-Search-Skill
+ + For Activities Skill: Install from Plasmoid (Follow Dependency Installation Below). Skill Name: Plasma-Activities-Skill
+ + For User Control Skill: Install from Plasmoid (Follow Dependency Installation Below). Skill Name: Plasma-User-Control-Skill
+ + For Wallpaper Change Skill: Install from Plasmoid (Follow Dependency Installation Below). Skill Name: Unsplash-Wallpaper-Plasma-Skill
+ + For Image Recognition Skill: Follow Instructions at: https://github.com/AIIX/clarifai-image-recognition-skill
+
+ To Install Skills With HTML Data:
+ + skill-weather: Replace /opt/mycroft/skills/skill-weather with https://github.com/AIIX/skill-weather
+    + git clone https://github.com/AIIX/skill-weather
+    + cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
+ 
+ + skill-stocks: Replace /opt/mycroft/skills/skill-stock with https://github.com/AIIX/skill-stock
+    + git clone https://github.com/AIIX/skill-stock
+    + cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
+    
+ + skill-wiki: Replace /opt/mycroft/skills/skill-wiki with https://github.com/AIIX/skill-wiki
+    + git clone https://github.com/AIIX/skill-wiki
+    + cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
+
+ To Install Plasma Desktop Skills(Manually) (Step 5. Dependency Install is Very Important):
+    + git clone https://github.com/AIIX/krunner-search-skill  
+    + cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
+    + git clone https://github.com/AIIX/plasma-activities-skill  
+    + cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
+    + git clone https://github.com/AIIX/plasma-user-control-skill
+    + cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
+    + git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
+    + cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
+    + git clone https://github.com/AIIX/clarifai-image-recognition-skill  
+    + cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
+    
+4. Skills Dependency Requirements
+
+ + For Skills (KDE Neon): sudo apt install python-dbus, python-pyqt5 pyqt5-dev, python-sip, python-sip-dev
+ + From Konsole: cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+ + From Konsole: cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+ + From Konsole: cp -R /usr/lib/python2.7/dist-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+ + From Konsole: cp /usr/lib/python2.7/dist-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+ 
+5. Skills Dependency for Other Distributions
+
+Python Dbus, PyQT5 and SIP package is required and copying the Python Dbus, Python QT folder and SIP libs from your system python install over to /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/.

--- a/kde_plasmoid_fedora/Readme.md
+++ b/kde_plasmoid_fedora/Readme.md
@@ -1,6 +1,14 @@
 # Mycroft Plasmoid // Release 2.0
 #### Mycroft Ai Plasmoid and Skills for KDE Plasma 5 Desktop
 
+Auto Install Instructions:
+
+1. git clone https://github.com/MycroftAI/installers/kde_plasmoid_fedora
+2. chmod +x install.sh
+3. ./install.sh
+
+Manual Install Instructions: 
+
 1. Installation Requirements
 
 This plasmoid requires Mycroft Core Installed from http://github.com/MycroftAi/ using the GIT Method:
@@ -64,7 +72,3 @@ This plasmoid requires Mycroft Core Installed from http://github.com/MycroftAi/ 
  + From Konsole: cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
  + From Konsole: cp -R /usr/lib/python2.7/dist-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
  + From Konsole: cp /usr/lib/python2.7/dist-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
- 
-5. Skills Dependency for Other Distributions
-
-Python Dbus, PyQT5 and SIP package is required and copying the Python Dbus, Python QT folder and SIP libs from your system python install over to /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/.

--- a/kde_plasmoid_fedora/Readme.md
+++ b/kde_plasmoid_fedora/Readme.md
@@ -1,9 +1,9 @@
 # Mycroft Plasmoid // Release 2.0
-#### Mycroft Ai Plasmoid and Skills for KDE Plasma 5 Desktop
+#### Mycroft AI Plasmoid and Skills for KDE Plasma 5 Desktop
 
 Auto Install Instructions:
 
-1. git clone https://github.com/MycroftAI/installers/kde_plasmoid_fedora
+1. wget https://raw.githubusercontent.com/MycroftAI/installers/master/kde_plasmoid_fedora/install.sh
 2. chmod +x install.sh
 3. ./install.sh
 
@@ -11,7 +11,7 @@ Manual Install Instructions:
 
 1. Installation Requirements
 
-This plasmoid requires Mycroft Core Installed from http://github.com/MycroftAi/ using the GIT Method:
+This plasmoid requires Mycroft Core Installed from http://github.com/MycroftAI/ using the GIT Method:
     + cd /home/$USER/
     + git clone https://github.com/MycroftAI/mycroft-core
     + For Fedora Run: ./build_host_setup_fedora.sh

--- a/kde_plasmoid_fedora/core_build.sh
+++ b/kde_plasmoid_fedora/core_build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Make sure we are in user's home directory
+cd ~
+
+echo "*****************************************************"
+echo "Installing git for pulling down source code"
+echo "*****************************************************"
+sudo dnf install git -y
+
+############################################################################
+# Retrieve and build Mycroft
+############################################################################
+
+# Pull down mycroft-core 
+git clone https://github.com/MycroftAI/mycroft-core.git
+
+# Build and install Mycroft: 
+cd mycroft-core
+
+echo "*****************************************************"
+echo "Getting Requirements."
+echo "*****************************************************"
+./build_host_setup_fedora.sh 
+echo "-----------------------------------------------------"
+echo "-----------------------------------------------------"

--- a/kde_plasmoid_fedora/core_build.sh
+++ b/kde_plasmoid_fedora/core_build.sh
@@ -12,7 +12,7 @@ sudo dnf install git -y
 ############################################################################
 
 # Pull down mycroft-core 
-git clone https://github.com/MycroftAI/mycroft-core.git
+#git clone https://github.com/MycroftAI/mycroft-core.git
 
 # Build and install Mycroft: 
 cd mycroft-core

--- a/kde_plasmoid_fedora/core_dev.sh
+++ b/kde_plasmoid_fedora/core_dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Make sure we are in user's home directory
+cd ~
+cd mycroft-core
+
+echo "*****************************************************"
+echo "The compiling can take a long time, up to 2 hours."
+echo "Go enjoy a movie, we'll finish the install.       "
+echo "*****************************************************"
+./dev_setup.sh
+echo "-----------------------------------------------------"
+echo "Whew, finally finished that!"
+echo "-----------------------------------------------------"

--- a/kde_plasmoid_fedora/install.sh
+++ b/kde_plasmoid_fedora/install.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+echo "**********************************************************************" 
+echo "                 Mycroft Plasmoid installation script                 " 
+echo "                                                                      " 
+echo "This script will download, build and install the Mycroft core and the " 
+echo "Mycroft KDE Plasmoid.  Special thanks to AIX for making all of this   " 
+echo "possible!                                                             " 
+echo "**********************************************************************" 
+echo "" 
+echo ""
+
+# Make sure we are in user's home directory
+cd ~
+
+echo "*****************************************************"
+echo "Installing git for pulling down source code"
+echo "*****************************************************"
+sudo dnf install git -y
+
+############################################################################
+# Retrieve and build Mycroft
+############################################################################
+
+# Pull down mycroft-core 
+git clone https://github.com/MycroftAI/mycroft-core.git
+
+# Build and install Mycroft: 
+cd mycroft-core
+
+echo "*****************************************************"
+echo "The compiling can take a long time, up to 2 hours." 
+echo "Go enjoy a movie, we'll finish the install.       "
+echo "*****************************************************"
+./build_host_setup_fedora.sh 
+./dev_setup.sh
+
+echo "-----------------------------------------------------"
+echo "Whew, finally finished that!  Now on to the Plasmoid "
+echo "-----------------------------------------------------"
+
+############################################################################
+# Retrieve and build the Plasmoid
+############################################################################
+
+cd ..
+# Pull down the Plasmoid code from KDE repos
+git clone https://anongit.kde.org/plasma-mycroft.git
+
+# Install all necessary supporting libraries and tools
+
+sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquick1-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-i18n-devel qt5-qtwebkit qt5-qtwebkit-devel -y
+
+# Build the Plasmoid
+cd plasma-mycroft
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
+make
+
+# Install the Plasmoid
+sudo make install
+
+# Set permissions on new files to allow execution
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/startservice.sh 
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/stopservice.sh
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstartservice.sh 
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
+
+############################################################################
+# Installing Skills Dependencies
+############################################################################
+
+# Install all necessary supporting libraries
+sudo dnf install dbus-python PyQt-devel sip sip-devel
+
+Arch=$(uname -m)
+
+if [ $Arch == 'i386' ]; then
+cp -R /usr/lib/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp /usr/lib/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp -R /usr/lib/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+cp /usr/lib/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+fi
+
+if [ $Arch == 'x86_64' ]; then
+cp -R /usr/lib64/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp /usr/lib64/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp -R /usr/lib64/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+cp /usr/lib64/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+fi
+
+# Get those awesome plasma skills
+git clone https://github.com/AIIX/krunner-search-skill  
+cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
+git clone https://github.com/AIIX/plasma-activities-skill  
+cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
+git clone https://github.com/AIIX/plasma-user-control-skill  
+cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
+git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
+cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
+git clone https://github.com/AIIX/clarifai-image-recognition-skill  
+cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
+
+#Get those display skills for the desktop
+git clone https://github.com/AIIX/skill-weather
+cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
+git clone https://github.com/AIIX/skill-stock
+cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
+git clone https://github.com/AIIX/skill-wiki
+cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
+
+# Restart the machine!
+echo "Everything is built and ready to go!"
+echo "After the machine reboots, you will need to activate it by:"
+echo "1) Right-clicking on the desktop and picking 'Add Widget...'"
+echo "2) Locating 'Mycroft' and dragging that to the desktop"
+echo "3) Click on the Plasmoid and press the 'Play' button"
+echo "4) Register your devices at https://home.mycroft.ai with the pairing code"
+echo "5) Say 'Hey Mycroft, what time is it?'"
+
+read -p "Press the [Enter] key to reboot..."
+sudo reboot now

--- a/kde_plasmoid_fedora/plasmaskills.sh
+++ b/kde_plasmoid_fedora/plasmaskills.sh
@@ -19,22 +19,27 @@ cp /usr/lib64/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/
 fi
 
 # Get those awesome plasma skills
-git clone https://github.com/AIIX/krunner-search-skill  
+git clone https://github.com/AIIX/krunner-search-skill
+mkdir /opt/mycroft/skills/krunner-search-skill/
 cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
-git clone https://github.com/AIIX/plasma-activities-skill  
-cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
-git clone https://github.com/AIIX/plasma-user-control-skill  
-cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
-git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
-cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
-git clone https://github.com/AIIX/clarifai-image-recognition-skill  
-cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
+git clone https://github.com/AIIX/plasma-activities-skill
+mkdir /opt/mycroft/skills/plasma-activities-skill/
+cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill
+git clone https://github.com/AIIX/plasma-user-control-skill
+mkdir /opt/mycroft/skills/plasma-user-control-skill/
+cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill
+git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill
+mkdir /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
+cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill
+git clone https://github.com/AIIX/clarifai-image-recognition-skill
+mkdir /opt/mycroft/skills/clarifai-image-recognition-skill/
+cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill
 
 #Get those display skills for the desktop
 git clone https://github.com/AIIX/skill-weather
-cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
+cp -R skill-weather/* /opt/mycroft/skills/skill-weather
 git clone https://github.com/AIIX/skill-stock
-cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
+cp -R skill-stock/* /opt/mycroft/skills/skill-stock
 git clone https://github.com/AIIX/skill-wiki
-cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
+cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki
 

--- a/kde_plasmoid_fedora/plasmaskills.sh
+++ b/kde_plasmoid_fedora/plasmaskills.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Make sure we are in user's home directory
+cd ~
+
+Arch=$(uname -m)
+
+if [ $Arch == 'i386' ]; then
+cp -R /usr/lib/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp /usr/lib/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp -R /usr/lib/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+cp /usr/lib/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+fi
+
+if [ $Arch == 'x86_64' ]; then
+cp -R /usr/lib64/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp /usr/lib64/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp -R /usr/lib64/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+cp /usr/lib64/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+fi
+
+# Get those awesome plasma skills
+git clone https://github.com/AIIX/krunner-search-skill  
+cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
+git clone https://github.com/AIIX/plasma-activities-skill  
+cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
+git clone https://github.com/AIIX/plasma-user-control-skill  
+cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
+git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
+cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
+git clone https://github.com/AIIX/clarifai-image-recognition-skill  
+cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
+
+#Get those display skills for the desktop
+git clone https://github.com/AIIX/skill-weather
+cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
+git clone https://github.com/AIIX/skill-stock
+cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
+git clone https://github.com/AIIX/skill-wiki
+cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
+

--- a/kde_plasmoid_fedora/plasmoid.sh
+++ b/kde_plasmoid_fedora/plasmoid.sh
@@ -36,41 +36,5 @@ sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/content
 # Install all necessary supporting libraries
 sudo dnf install dbus-python PyQt-devel sip sip-devel
 
-Arch=$(uname -m)
-
-if [ $Arch == 'i386' ]; then
-cp -R /usr/lib/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp /usr/lib/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp -R /usr/lib/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
-cp /usr/lib/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-fi
-
-if [ $Arch == 'x86_64' ]; then
-cp -R /usr/lib64/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp /usr/lib64/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp -R /usr/lib64/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
-cp /usr/lib64/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-fi
-
-# Get those awesome plasma skills
-git clone https://github.com/AIIX/krunner-search-skill  
-cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
-git clone https://github.com/AIIX/plasma-activities-skill  
-cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
-git clone https://github.com/AIIX/plasma-user-control-skill  
-cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
-git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
-cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
-git clone https://github.com/AIIX/clarifai-image-recognition-skill  
-cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
-
-#Get those display skills for the desktop
-git clone https://github.com/AIIX/skill-weather
-cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
-git clone https://github.com/AIIX/skill-stock
-cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
-git clone https://github.com/AIIX/skill-wiki
-cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
-
 # Restart the machine!
 echo "Everything is built and ready to go!"

--- a/kde_plasmoid_fedora/plasmoid.sh
+++ b/kde_plasmoid_fedora/plasmoid.sh
@@ -11,7 +11,7 @@ git clone https://anongit.kde.org/plasma-mycroft.git
 
 # Install all necessary supporting libraries and tools
 
-sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquick1-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-i18n-devel qt5-qtwebkit qt5-qtwebkit-devel -y
+sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-ki18n-devel qt5-qtwebkit qt5-qtwebkit-devel -y
 
 # Build the Plasmoid
 cd plasma-mycroft

--- a/kde_plasmoid_fedora/plasmoid.sh
+++ b/kde_plasmoid_fedora/plasmoid.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Make sure we are in user's home directory
+cd ~
+
+############################################################################
+# Retrieve and build the Plasmoid
+############################################################################
+
+# Pull down the Plasmoid code from KDE repos
+git clone https://anongit.kde.org/plasma-mycroft.git
+
+# Install all necessary supporting libraries and tools
+
+sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquick1-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-i18n-devel qt5-qtwebkit qt5-qtwebkit-devel -y
+
+# Build the Plasmoid
+cd plasma-mycroft
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
+make
+
+# Install the Plasmoid
+sudo make install
+
+# Set permissions on new files to allow execution
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/startservice.sh 
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/stopservice.sh
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstartservice.sh 
+sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
+
+############################################################################
+# Installing Skills Dependencies
+############################################################################
+
+# Install all necessary supporting libraries
+sudo dnf install dbus-python PyQt-devel sip sip-devel
+
+Arch=$(uname -m)
+
+if [ $Arch == 'i386' ]; then
+cp -R /usr/lib/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp /usr/lib/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp -R /usr/lib/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+cp /usr/lib/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+fi
+
+if [ $Arch == 'x86_64' ]; then
+cp -R /usr/lib64/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp /usr/lib64/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+cp -R /usr/lib64/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
+cp /usr/lib64/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
+fi
+
+# Get those awesome plasma skills
+git clone https://github.com/AIIX/krunner-search-skill  
+cp -R krunner-search-skill/* /opt/mycroft/skills/krunner-search-skill/
+git clone https://github.com/AIIX/plasma-activities-skill  
+cp -R plasma-activities-skill/* /opt/mycroft/skills/plasma-activities-skill/
+git clone https://github.com/AIIX/plasma-user-control-skill  
+cp -R plasma-user-control-skill/* /opt/mycroft/skills/plasma-user-control-skill/
+git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
+cp -R unsplash-wallpaper-plasma-skill/* /opt/mycroft/skills/unsplash-wallpaper-plasma-skill/
+git clone https://github.com/AIIX/clarifai-image-recognition-skill  
+cp -R clarifai-image-recognition-skill/* /opt/mycroft/skills/clarifai-image-recognition-skill/
+
+#Get those display skills for the desktop
+git clone https://github.com/AIIX/skill-weather
+cp -R skill-weather/* /opt/mycroft/skills/skill-weather/
+git clone https://github.com/AIIX/skill-stock
+cp -R skill-stock/* /opt/mycroft/skills/skill-stock/
+git clone https://github.com/AIIX/skill-wiki
+cp -R skill-wiki/* /opt/mycroft/skills/skill-wiki/
+
+# Restart the machine!
+echo "Everything is built and ready to go!"

--- a/kde_plasmoid_fedora/plasmoid.sh
+++ b/kde_plasmoid_fedora/plasmoid.sh
@@ -11,7 +11,7 @@ git clone https://anongit.kde.org/plasma-mycroft.git
 
 # Install all necessary supporting libraries and tools
 
-sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquick1-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-i18n-devel qt5-qtwebkit qt5-qtwebkit-devel -y
+sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-ki18n-devel qt5-qtwebkit qt5-qtwebkit-devel -y
 
 # Build the Plasmoid
 cd plasma-mycroft
@@ -34,7 +34,7 @@ sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/content
 ############################################################################
 
 # Install all necessary supporting libraries
-sudo dnf install dbus-python PyQt-devel sip sip-devel
+sudo dnf install dbus-python PyQt-devel sip-devel
 
 # Restart the machine!
 echo "Everything is built and ready to go!"


### PR DESCRIPTION
The installer.sh in debian was missing the step to git clone the plasmoid, added the git clone step to the plasmoid.