### PR TITLE
Use enclosure based MSM default skills install mechanism

### DIFF
--- a/kde_plasmoid_debian/Readme.md
+++ b/kde_plasmoid_debian/Readme.md
@@ -17,7 +17,9 @@ Manual Install Instructions:
     + Run: ./dev_setup.sh
 
 2. Installation Instructions
-  + Konsole: sudo apt-get install libkf5notifications-data libkf5notifications-dev qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-controls qml-module-qtwebsockets qml-module-qt-websockets qtdeclarative5-qtquick2-plugin qtdeclarative5-models-plugin cmake cmake-extras cmake-data qml-module-qtquick-layouts libkf5plasma-dev extra-cmake-modules qtdeclarative5-dev build-essential g++ gettext libqt5webkit5 libqt5webkit5-dev libkf5i18n-data libkf5i18n-dev libkf5i18n5 qml-module-qtgraphicaleffects -y
+
+  + Konsole: sudo apt-get install libkf5notifications-data libkf5notifications-dev qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-controls qml-module-qtwebsockets qml-module-qt-websockets qtdeclarative5-qtquick2-plugin qtdeclarative5-models-plugin cmake cmake-extras cmake-data qml-module-qtquick-layouts libkf5plasma-dev extra-cmake-modules qtdeclarative5-dev build-essential g++ gettext libqt5webkit5 libqt5webkit5-dev libkf5i18n-data libkf5i18n-dev libkf5i18n5 qml-module-qtgraphicaleffects libdbus-1-dev libdbus-glib-1-dev -y
+
   + git clone https://anongit.kde.org/plasma-mycroft.git/
   + cd plasma-mycroft
   + mkdir build
@@ -31,7 +33,7 @@ Manual Install Instructions:
   + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
   + Logout / Login or Restart Plasma Shell
 
-3. 3. KDE Platform Skills Installation
+3. Visual Display Skills Installation
 
 Install Skills With HTML Displays:
  + skill-weather: Replace /opt/mycroft/skills/skill-weather with https://github.com/AIIX/skill-weather
@@ -46,18 +48,3 @@ Install Skills with Dynamic QML Displays:
  + skill-wiki: Replace /opt/mycroft/skills/skill-wiki with https://github.com/AIIX/skill-wiki
     + cd /opt/mycroft/skills
     + git clone https://github.com/AIIX/skill-wiki
-
- To Install Plasma Desktop Skills(Manually) (Skills Dependency Install is Very Important):
-    + git clone https://github.com/AIIX/krunner-search-skill  
-    + git clone https://github.com/AIIX/plasma-activities-skill  
-    + git clone https://github.com/AIIX/plasma-user-control-skill
-    + git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
-    + git clone https://github.com/AIIX/clarifai-image-recognition-skill  
-    
-4. Skills Dependency Requirements
-
- + For Skills (KDE Neon): sudo apt install python-dbus, python-pyqt5 pyqt5-dev, python-sip, python-sip-dev
- + From Konsole: cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
- + From Konsole: cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
- + From Konsole: cp -R /usr/lib/python2.7/dist-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
- + From Konsole: cp /usr/lib/python2.7/dist-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/

--- a/kde_plasmoid_debian/install.sh
+++ b/kde_plasmoid_debian/install.sh
@@ -34,10 +34,10 @@ echo "Go enjoy a movie, we'll finish the install.       "
 echo "*****************************************************"
 
 ./dev_setup.sh
+
 echo "-----------------------------------------------------"
 echo "Whew, finally finished that!  Now on to the Plasmoid "
 echo "-----------------------------------------------------"
-
 
 ############################################################################
 # Retrieve and build the Plasmoid
@@ -48,7 +48,7 @@ cd ..
 git clone https://anongit.kde.org/plasma-mycroft.git
 
 # Install all necessary supporting libraries and tools
-sudo apt-get install libkf5notifications-data libkf5notifications-dev qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-controls qml-module-qtwebsockets qml-module-qt-websockets qtdeclarative5-qtquick2-plugin qtdeclarative5-models-plugin cmake cmake-extras cmake-data qml-module-qtquick-layouts libkf5plasma-dev extra-cmake-modules qtdeclarative5-dev build-essential g++ gettext libqt5webkit5 libqt5webkit5-dev libkf5i18n-data libkf5i18n-dev libkf5i18n5 qml-module-qtgraphicaleffects -y
+sudo apt-get install libkf5notifications-data libkf5notifications-dev qml-module-qtquick2 qml-module-qtquick-controls2 qml-module-qtquick-controls qml-module-qtwebsockets qml-module-qt-websockets qtdeclarative5-qtquick2-plugin qtdeclarative5-models-plugin cmake cmake-extras cmake-data qml-module-qtquick-layouts libkf5plasma-dev extra-cmake-modules qtdeclarative5-dev build-essential g++ gettext libqt5webkit5 libqt5webkit5-dev libkf5i18n-data libkf5i18n-dev libkf5i18n5 qml-module-qtgraphicaleffects libdbus-1-dev libdbus-glib-1-dev -y
 
 # Build the Plasmoid
 cd plasma-mycroft
@@ -65,46 +65,6 @@ sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/content
 sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/stopservice.sh
 sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstartservice.sh
 sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
-
-############################################################################
-# Installing Skills Dependencies
-############################################################################
-
-# Install all necessary supporting libraries
-sudo apt-get install python-dbus python-pyqt5 pyqt5-dev python-sip python-sip-dev
-
-cp -R /usr/lib/python2.7/dist-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp /usr/lib/python2.7/dist-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp -R /usr/lib/python2.7/dist-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
-cp /usr/lib/python2.7/dist-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-
-# Test mycroft service and install default skills
-cd ~
-secs=$((60 * 4))
-cd mycroft-core
-./start-mycroft.sh all
-while [ $secs -gt 0 ]; do
-   echo -ne "Please Wait.. $secs (secs)\033[0K\r"
-   sleep 1
-   : $((secs--))
-done
-./stop-mycroft.sh
-echo "-----------------------------------"
-echo "Getting those awesome plasma skills"
-echo "-----------------------------------"
-
-# Get those awesome plasma skills
-cd /opt/mycroft/skills/
-git clone https://github.com/AIIX/krunner-search-skill  
-git clone https://github.com/AIIX/plasma-activities-skill  
-git clone https://github.com/AIIX/plasma-user-control-skill  
-git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
-git clone https://github.com/AIIX/clarifai-image-recognition-skill  
-
-#Get those display skills for the desktop
-git clone https://github.com/AIIX/skill-weather
-git clone https://github.com/AIIX/skill-stock
-git clone https://github.com/AIIX/skill-wiki
 
 # Restart the machine!
 echo "Everything is built and ready to go!"

--- a/kde_plasmoid_fedora/Readme.md
+++ b/kde_plasmoid_fedora/Readme.md
@@ -17,7 +17,7 @@ Manual Install Instructions:
     + Run: ./dev_setup.sh
 
 2. Installation Instructions
-  + Open Konsole: sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-ki18n-devel qt5-qtwebkit qt5-qtwebkit-devel qt5-qtgraphicaleffects -y
+  + Open Konsole: sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-ki18n-devel qt5-qtwebkit qt5-qtwebkit-devel qt5-qtgraphicaleffects dbus-devel dbus-glib-devel -y
   + git clone https://anongit.kde.org/plasma-mycroft.git/
   + cd plasma-mycroft
   + mkdir build
@@ -31,7 +31,7 @@ Manual Install Instructions:
   + sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
   + Logout / Login or Restart Plasma Shell
 
-3. KDE Platform Skills Installation
+3. Visual Display Skills Installation
 
 Install Skills With HTML Displays:
  + skill-weather: Replace /opt/mycroft/skills/skill-weather with https://github.com/AIIX/skill-weather
@@ -47,17 +47,3 @@ Install Skills with Dynamic QML Displays:
     + cd /opt/mycroft/skills
     + git clone https://github.com/AIIX/skill-wiki
 
- To Install Plasma Desktop Skills(Manually) (Skills Dependency Install is Very Important):
-    + git clone https://github.com/AIIX/krunner-search-skill  
-    + git clone https://github.com/AIIX/plasma-activities-skill  
-    + git clone https://github.com/AIIX/plasma-user-control-skill
-    + git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
-    + git clone https://github.com/AIIX/clarifai-image-recognition-skill  
-    
-4. Skills Dependency Requirements
-
- + For Skills (Fedora): sudo dnf install dbus-python pyqt5-devel sip sip-devel
- + From Konsole: cp -R /usr/lib64/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
- + From Konsole: cp /usr/lib64/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
- + From Konsole: cp -R /usr/lib64/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
- + From Konsole: cp /usr/lib64/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/

--- a/kde_plasmoid_fedora/install.sh
+++ b/kde_plasmoid_fedora/install.sh
@@ -48,8 +48,7 @@ cd ..
 git clone https://anongit.kde.org/plasma-mycroft.git
 
 # Install all necessary supporting libraries and tools
-
-sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-ki18n-devel qt5-qtwebkit qt5-qtwebkit-devel qt5-qtgraphicaleffects -y
+sudo dnf install kf5-knotifications-devel qt5-qtbase-devel qt5-qtdeclarative-devel qt5-qtquickcontrols qt5-qtquickcontrols2 qt5-qtwebsockets qt5-qtwebsockets-devel cmake extra-cmake-modules kf5-plasma-devel kf5-ki18n-devel qt5-qtwebkit qt5-qtwebkit-devel qt5-qtgraphicaleffects dbus-devel dbus-glib-devel -y
 
 # Build the Plasmoid
 cd plasma-mycroft
@@ -66,57 +65,6 @@ sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/content
 sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/stopservice.sh
 sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstartservice.sh 
 sudo chmod +x /usr/share/plasma/plasmoids/org.kde.plasma.mycroftplasmoid/contents/code/pkgstopservice.sh
-
-############################################################################
-# Installing Skills Dependencies
-############################################################################
-
-# Install all necessary supporting libraries
-sudo dnf install dbus-python pyqt5-devel sip sip-devel
-
-Arch=$(uname -m)
-
-if [ $Arch == 'i386' ]; then
-cp -R /usr/lib/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp /usr/lib/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp -R /usr/lib/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
-cp /usr/lib/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-fi
-
-if [ $Arch == 'x86_64' ]; then
-cp -R /usr/lib64/python2.7/site-packages/dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp /usr/lib64/python2.7/site-packages/_dbus* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-cp -R /usr/lib64/python2.7/site-packages/PyQt5* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/    
-cp /usr/lib64/python2.7/site-packages/sip* /home/$USER/.virtualenvs/mycroft/lib/python2.7/site-packages/
-fi
-
-# Test mycroft service and install default skills
-cd ~
-secs=$((60 * 4))
-cd mycroft-core
-./start-mycroft.sh all
-while [ $secs -gt 0 ]; do
-   echo -ne "Please Wait.. $secs (secs)\033[0K\r"
-   sleep 1
-   : $((secs--))
-done
-./stop-mycroft.sh
-echo "-----------------------------------"
-echo "Getting those awesome plasma skills"
-echo "-----------------------------------"
-
-# Get those awesome plasma skills
-cd /opt/mycroft/skills/
-git clone https://github.com/AIIX/krunner-search-skill  
-git clone https://github.com/AIIX/plasma-activities-skill  
-git clone https://github.com/AIIX/plasma-user-control-skill  
-git clone https://github.com/AIIX/unsplash-wallpaper-plasma-skill  
-git clone https://github.com/AIIX/clarifai-image-recognition-skill  
-
-#Get those display skills for the desktop
-git clone https://github.com/AIIX/skill-weather
-git clone https://github.com/AIIX/skill-stock
-git clone https://github.com/AIIX/skill-wiki
 
 # Restart the machine!
 echo "Everything is built and ready to go!"


### PR DESCRIPTION
Removed skill installation from installation scripts and readme, enclosure installs it own system wide mycroft.conf with platform specified for platform specific default skill installs